### PR TITLE
Prevent hiding the handle while grabbed

### DIFF
--- a/fastscroll/src/main/java/com/futuremind/recyclerviewfastscroll/ScrollerViewProvider.java
+++ b/fastscroll/src/main/java/com/futuremind/recyclerviewfastscroll/ScrollerViewProvider.java
@@ -15,6 +15,8 @@ public abstract class ScrollerViewProvider {
     private VisibilityAnimationManager bubbleVisibilityManager;
     private VisibilityAnimationManager handleVisibilityManager;
 
+    private boolean isGrabbed;
+
     void setFastScroller(FastScroller scroller){
         this.scroller = scroller;
     }
@@ -73,11 +75,13 @@ public abstract class ScrollerViewProvider {
     }
 
     protected void handleGrabbed(){
+        isGrabbed = true;
         if(getBubbleVisibilityManager()!=null) getBubbleVisibilityManager().show();
         if(getHandleVisibilityManager()!=null) getHandleVisibilityManager().show();
     }
 
     protected void handleReleased(){
+        isGrabbed = false;
         if(getBubbleVisibilityManager()!=null) getBubbleVisibilityManager().hide();
         if(getHandleVisibilityManager()!=null) getHandleVisibilityManager().hide();
     }
@@ -87,7 +91,7 @@ public abstract class ScrollerViewProvider {
     }
 
     protected void onScrollFinished(){
-        if(getHandleVisibilityManager()!=null) getHandleVisibilityManager().hide();
+        if(getHandleVisibilityManager()!=null && !isGrabbed) getHandleVisibilityManager().hide();
     }
 
 }


### PR DESCRIPTION
If the handle is grabbed in some cases, onScrollFinished is called after handleGrabbed (zero delay, grab handle with a second finger while scrolling normally).