### PR TITLE
DefaultScrollerViewProvider: Change visibilty of handle and bubble to protected

### DIFF
--- a/fastscroll/src/main/java/com/futuremind/recyclerviewfastscroll/viewprovider/DefaultScrollerViewProvider.java
+++ b/fastscroll/src/main/java/com/futuremind/recyclerviewfastscroll/viewprovider/DefaultScrollerViewProvider.java
@@ -15,8 +15,8 @@ import com.futuremind.recyclerviewfastscroll.Utils;
  */
 public class DefaultScrollerViewProvider extends ScrollerViewProvider {
 
-    private View bubble;
-    private View handle;
+    protected View bubble;
+    ptotected View handle;
 
     @Override
     public View provideHandleView(ViewGroup container) {


### PR DESCRIPTION
Allow subclasses to piggyback on the default implementation, but change small details (i.e. just changing the behavior of the handle, while leaving everything else in place)